### PR TITLE
Add service class for Firestore and conversion functions

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -19,18 +19,23 @@ jobs:
         sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
         sudo apt-get update
         sudo apt-get install dart
+    - name: Install Protoc
+      run: |
+        sudo apt-get install protobuf-compiler
+        PATH="$PATH:/usr/lib/dart/bin" pub global activate protoc_plugin
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: PATH="$PATH:/usr/lib/dart/bin" pub get
     - name: Run tests
       run: PATH="$PATH:/usr/lib/dart/bin" pub run build_runner test -- -p chrome
     - name: Install dependencies for rules builder
-      uses: arduino/setup-protoc@v1
+      run: PATH="$PATH:/usr/lib/dart/bin" pub get
+      working-directory: ./server
+      if: always()
+    - name: Generate protobufs for rules builder
       run: |
         mkdir -p lib/proto
-        protoc --dart_out=lib/proto/ --proto_path=../ rule.proto
-        PATH="$PATH:/usr/lib/dart/bin" pub get
-      working-directory: ./server
+        protoc --dart_out=server/lib/proto/ rule.proto
       if: always()
     - name: Run tests for rules builder
       run: PATH="$PATH:/usr/lib/dart/bin" pub run test test/*

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -25,7 +25,11 @@ jobs:
     - name: Run tests
       run: PATH="$PATH:/usr/lib/dart/bin" pub run build_runner test -- -p chrome
     - name: Install dependencies for rules builder
-      run: PATH="$PATH:/usr/lib/dart/bin" pub get 
+      uses: arduino/setup-protoc@v1
+      run: |
+        mkdir -p lib/proto
+        protoc --dart_out=lib/proto/ --proto_path=../ rule.proto
+        PATH="$PATH:/usr/lib/dart/bin" pub get
       working-directory: ./server
       if: always()
     - name: Run tests for rules builder

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -34,7 +34,7 @@ jobs:
       if: always()
     - name: Generate protobufs for rules builder
       run: |
-        mkdir -p lib/proto
+        mkdir -p server/lib/proto
         PATH="$PATH:$HOME/.pub-cache/bin" protoc --dart_out=server/lib/proto/ rule.proto
       if: always()
     - name: Run tests for rules builder

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Generate protobufs for rules builder
       run: |
         mkdir -p lib/proto
-        protoc --dart_out=server/lib/proto/ rule.proto
+        PATH="$PATH:$HOME/.pub-cache/bin" protoc --dart_out=server/lib/proto/ rule.proto
       if: always()
     - name: Run tests for rules builder
       run: PATH="$PATH:/usr/lib/dart/bin" pub run test test/*

--- a/rule.proto
+++ b/rule.proto
@@ -79,4 +79,8 @@ message Schedule {
   oneof params {
     RepeatingParams repeating_params = 2;
   }
+
+  // required
+  // The timezone name of the scheduled job from the tz database.
+  optional string timezone = 3;
 }

--- a/rule.proto
+++ b/rule.proto
@@ -82,5 +82,6 @@ message Schedule {
 
   // required
   // The timezone name of the scheduled job from the tz database.
+  // See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   optional string timezone = 3;
 }

--- a/server/analysis_options.yaml
+++ b/server/analysis_options.yaml
@@ -7,7 +7,6 @@ analyzer:
 linter:
   rules:
     - always_declare_return_types
-    - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
     - always_require_non_null_named_parameters
     - annotate_overrides

--- a/server/config.src.yaml
+++ b/server/config.src.yaml
@@ -1,6 +1,11 @@
 clientId: clientid
 clientSecret: clientsecret
+projectId: projectId
+databaseId: (default)
 
 displayVideo360:
   baseURL: https://localhost:8001/
+
+firestore:
+  baseURL: https://localhost:8002/
 

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -1,5 +1,10 @@
 clientId: $CLIENT_ID
 clientSecret: $CLIENT_SECRET
+projectId: $PROJECT_ID
+databaseId: (default)
 
 displayVideo360:
   baseURL: https://displayvideo.googleapis.com/
+
+firestore:
+  baseURL: https://firestore.googleapis.com/

--- a/server/lib/channel.dart
+++ b/server/lib/channel.dart
@@ -38,7 +38,11 @@ class ServerChannel extends ApplicationChannel {
 class ServerConfiguration extends Configuration {
   String clientId;
   String clientSecret;
+  String projectId;
+  String databaseId;
+
   APIConfiguration displayVideo360;
+  APIConfiguration firestore;
 
   ServerConfiguration(String path) : super.fromFile(File(path));
 }

--- a/server/lib/service/firestore.dart
+++ b/server/lib/service/firestore.dart
@@ -44,6 +44,9 @@ class FirestoreClient {
 
   /// Adds a user to the Firestore database with the encrypted refresh token.
   ///
+  /// The [userId] is the `sub` claim of the user's Google ID token.
+  /// See: https://developers.google.com/identity/protocols/oauth2/openid-connect#an-id-tokens-payload
+  ///
   /// Throws an [ApiRequestError] if Firestore API returns an error.
   Future<void> createUser(String userId, String encryptedRefreshToken) async {
     final document = Document()

--- a/server/lib/service/firestore.dart
+++ b/server/lib/service/firestore.dart
@@ -7,10 +7,10 @@ import '../utils.dart';
 /// A class that wraps around Cloud Firestore.
 class FirestoreClient {
   /// The name of collection of users in Firestore.
-  static const usersCollectionName = 'users';
+  static const usersName = 'users';
 
   /// The name of the collection of rules in Firestore.
-  static const rulesCollectionName = 'rules';
+  static const rulesName = 'rules';
 
   /// The name of the encrypted refresh token field in Firestore.
   static const encryptedRefreshTokenFieldName = 'encryptedRefreshToken';
@@ -19,33 +19,30 @@ class FirestoreClient {
   final FirestoreApi _api;
 
   /// The Google Cloud project ID.
-  final String projectId;
+  final String _projectId;
 
   /// The Cloud Firestore database ID.
-  final String databaseId;
+  final String _databaseId;
 
   /// Creates an instance of [FirestoreClient].
   FirestoreClient(
-      Client client, this.projectId, this.databaseId, String baseUrl)
+      Client client, this._projectId, this._databaseId, String baseUrl)
       : _api = FirestoreApi(client, rootUrl: baseUrl);
 
-  /// Adds a rule to the Firestore database.
-  ///
-  /// The [rule] is an instance of [Rule], a protobuf generated class.
+  /// Adds a protobuf generated [Rule] to the Firestore database.
   ///
   /// Throws an [ApiRequestError] if Firestore API returns an error.
   Future<String> createRule(String userId, Rule rule) async {
     final document = rule.toDocument();
 
     return await _addDocument(
-      '/$usersCollectionName/$userId',
-      rulesCollectionName,
+      '/$usersName/$userId',
+      rulesName,
       document,
     );
   }
 
-  /// Adds a user to the Firestore database along with the encrypted refresh
-  /// token.
+  /// Adds a user to the Firestore database with the encrypted refresh token.
   ///
   /// Throws an [ApiRequestError] if Firestore API returns an error.
   Future<void> createUser(String userId, String encryptedRefreshToken) async {
@@ -57,7 +54,7 @@ class FirestoreClient {
 
     await _addDocument(
       '',
-      usersCollectionName,
+      usersName,
       document,
       documentId: userId,
     );
@@ -67,7 +64,7 @@ class FirestoreClient {
   ///
   /// Throws an [ApiRequestError] if Firestore API returns an error.
   Future<String> getEncryptedUserRefreshToken(String userId) async {
-    final document = await _getDocument('/$usersCollectionName/$userId');
+    final document = await _getDocument('/$usersName/$userId');
 
     final encryptedRefreshToken =
         document.fields[encryptedRefreshTokenFieldName].stringValue;
@@ -75,12 +72,12 @@ class FirestoreClient {
     return encryptedRefreshToken;
   }
 
-  /// Get a [Document] located at [path] from Firestore.
+  /// Gets a [Document] located at [path] from Firestore.
   ///
   /// Throws an [ApiRequestError] if Firestore API returns an error.
   Future<Document> _getDocument(String path) async {
     final document = await _api.projects.databases.documents
-        .get('projects/$projectId/databases/$databaseId/documents$path');
+        .get('projects/$_projectId/databases/$_databaseId/documents$path');
 
     return document;
   }
@@ -90,7 +87,7 @@ class FirestoreClient {
   /// The [parent] is the parent resource. This can be
   /// `projects/$projectId/databases/$databaseId/documents` or any sub-document.
   ///
-  /// The [collection] is the name of the collection relative to [parent] where
+  /// The [collectionName] is the name of the collection relative to [parent] where
   /// the new document will be added.
   ///
   /// The [documentId] optionally allows a custom name for the document.
@@ -98,12 +95,12 @@ class FirestoreClient {
   /// Throws an [ApiRequestError] if Firestore API returns an error.
   /// Returns the name of the new document.
   Future<String> _addDocument(
-      String parent, String collection, Document document,
+      String parent, String collectionName, Document document,
       {String documentId}) async {
     final newDocument = await _api.projects.databases.documents.createDocument(
         document,
-        'projects/$projectId/databases/$databaseId/documents$parent',
-        collection,
+        'projects/$_projectId/databases/$_databaseId/documents$parent',
+        collectionName,
         documentId: documentId);
 
     // [Document.name] is the resource name.

--- a/server/lib/service/firestore.dart
+++ b/server/lib/service/firestore.dart
@@ -1,0 +1,117 @@
+import 'package:googleapis/firestore/v1.dart';
+import 'package:http/http.dart';
+
+import '../proto/rule.pb.dart';
+import '../utils.dart';
+
+/// A class that wraps around Cloud Firestore.
+class FirestoreClient {
+  /// The name of collection of users in Firestore.
+  static const usersCollectionName = 'users';
+
+  /// The name of the collection of rules in Firestore.
+  static const rulesCollectionName = 'rules';
+
+  /// The name of the encrypted refresh token field in Firestore.
+  static const encryptedRefreshTokenFieldName = 'encryptedRefreshToken';
+
+  /// The Firestore API.
+  final FirestoreApi _api;
+
+  /// The Google Cloud project ID.
+  final String projectId;
+
+  /// The Cloud Firestore database ID.
+  final String databaseId;
+
+  /// Creates an instance of [FirestoreClient].
+  FirestoreClient(
+      Client client, this.projectId, this.databaseId, String baseUrl)
+      : _api = FirestoreApi(client, rootUrl: baseUrl);
+
+  /// Adds a rule to the Firestore database.
+  ///
+  /// The [rule] is an instance of [Rule], a protobuf generated class.
+  ///
+  /// Throws an [ApiRequestError] if Firestore API returns an error.
+  Future<String> createRule(String userId, Rule rule) async {
+    final document = rule.toDocument();
+
+    return await _addDocument(
+      '/$usersCollectionName/$userId',
+      rulesCollectionName,
+      document,
+    );
+  }
+
+  /// Adds a user to the Firestore database along with the encrypted refresh
+  /// token.
+  ///
+  /// Throws an [ApiRequestError] if Firestore API returns an error.
+  Future<void> createUser(String userId, String encryptedRefreshToken) async {
+    final document = Document()
+      ..fields = {
+        encryptedRefreshTokenFieldName: Value()
+          ..stringValue = encryptedRefreshToken
+      };
+
+    await _addDocument(
+      '',
+      usersCollectionName,
+      document,
+      documentId: userId,
+    );
+  }
+
+  /// Gets the user's encrypted refresh token given the [userId].
+  ///
+  /// Throws an [ApiRequestError] if Firestore API returns an error.
+  Future<String> getEncryptedUserRefreshToken(String userId) async {
+    final document = await _getDocument('/$usersCollectionName/$userId');
+
+    final encryptedRefreshToken =
+        document.fields[encryptedRefreshTokenFieldName].stringValue;
+
+    return encryptedRefreshToken;
+  }
+
+  /// Get a [Document] located at [path] from Firestore.
+  ///
+  /// Throws an [ApiRequestError] if Firestore API returns an error.
+  Future<Document> _getDocument(String path) async {
+    final document = await _api.projects.databases.documents
+        .get('projects/$projectId/databases/$databaseId/documents$path');
+
+    return document;
+  }
+
+  /// Adds a document to the Firestore database.
+  ///
+  /// The [parent] is the parent resource. This can be
+  /// `projects/$projectId/databases/$databaseId/documents` or any sub-document.
+  ///
+  /// The [collection] is the name of the collection relative to [parent] where
+  /// the new document will be added.
+  ///
+  /// The [documentId] optionally allows a custom name for the document.
+  ///
+  /// Throws an [ApiRequestError] if Firestore API returns an error.
+  /// Returns the name of the new document.
+  Future<String> _addDocument(
+      String parent, String collection, Document document,
+      {String documentId}) async {
+    final newDocument = await _api.projects.databases.documents.createDocument(
+        document,
+        'projects/$projectId/databases/$databaseId/documents$parent',
+        collection,
+        documentId: documentId);
+
+    // [Document.name] is the resource name.
+    // For example: projects/$projectId/databases/$databaseId/documents$path
+    // To get the name of the document, we have to split it by '/' and get the
+    // last string.
+    final documentName = newDocument.name.split('/').last;
+
+    return documentName;
+  }
+}

--- a/server/lib/utils.dart
+++ b/server/lib/utils.dart
@@ -14,12 +14,11 @@ extension DocumentConversion on Rule {
   /// [Value] is a union type. See:
   /// https://pub.dev/documentation/googleapis/latest/googleapis.firestore.v1/Value-class.html
   ///
-  /// We will first convert the protobuf [Rule] to a JSON format before
-  /// converting to [Document]. In this way, we can minimize coupling
-  /// between the proto schema and how we construct the document
-  /// (and vice versa).
+  /// We will first convert [Rule] to a JSON format before converting to
+  /// [Document]. In this way, we can minimize coupling between the proto schema
+  /// and how we construct the document (and vice versa).
   Document toDocument() {
-    // First, transform the Rule into a standard JSON string.
+    // First, transform the [Rule] into a standard JSON string.
     // [toProto3Json()] is used to convert to the proto3 JSON format instead of
     // [writeToJson()] because the representation is much more readable.
     final jsonString = jsonEncode(toProto3Json());

--- a/server/lib/utils.dart
+++ b/server/lib/utils.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+
+import 'package:fixnum/fixnum.dart';
+import 'package:googleapis/firestore/v1.dart';
+
+import 'proto/rule.pb.dart';
+
+/// An extension on the [Rule] protobuf generated class.
+extension DocumentConversion on Rule {
+  /// Extends the [Rule] protobuf generated class to be able to convert to a
+  /// Firestore [Document].
+  ///
+  /// This is necessary because [Document.fields] is a map with [Value] values.
+  /// [Value] is a union type. See:
+  /// https://pub.dev/documentation/googleapis/latest/googleapis.firestore.v1/Value-class.html
+  ///
+  /// We will first convert the protobuf [Rule] to a JSON format before
+  /// converting to [Document]. In this way, we can minimize coupling
+  /// between the proto schema and how we construct the document
+  /// (and vice versa).
+  Document toDocument() {
+    // First, transform the Rule into a standard JSON string.
+    // [toProto3Json()] is used to convert to the proto3 JSON format instead of
+    // [writeToJson()] because the representation is much more readable.
+    final jsonString = jsonEncode(toProto3Json());
+
+    // Next, decode the JSON string into a JSON object.
+    // We pass in a reviver function [packValue()] that is called for every
+    // object that is parsed while decoding. This allows us to transform it
+    // into a valid [Document] structure.
+    final transformedJsonObject =
+        jsonDecode(jsonString, reviver: packValue)['mapValue'];
+
+    return Document.fromJson(transformedJsonObject as Map<dynamic, dynamic>);
+  }
+}
+
+/// An extension on the Firestore [Document] class.
+extension ProtoConversion on Document {
+  /// Extends the [Document] class to be able to convert to a protobuf
+  /// generated [Rule].
+  ///
+  /// This is necessary because [Document.fields] is a map with [Value] values.
+  /// [Value] is a union type. See:
+  /// https://pub.dev/documentation/googleapis/latest/googleapis.firestore.v1/Value-class.html
+  ///
+  /// We will first convert the [Document] to a JSON format before converting
+  /// to [Rule]. In this way, we can minimize coupling between the proto schema
+  /// and the document.
+  Rule toProto() {
+    // First, create a [Value] with a mapValue set to the fields in the
+    // [Document].
+    final documentJsonFormat = Value()
+      ..mapValue = (MapValue()..fields = fields);
+
+    // Next, convert unpack each [Value] recursively into a valid JSON
+    // protobuf format.
+    final protoJsonFormat = unpackValue(documentJsonFormat);
+
+    // Finally, create and return the [Rule] from the JSON object.
+    return Rule()..mergeFromProto3Json(protoJsonFormat);
+  }
+}
+
+/// Converts an object with type T to a [Value] structured object depending
+/// on type T.
+///
+/// Can be used as a reviver function when parsing a JSON string with
+/// [jsonDecode()].
+Object packValue(Object key, Object value) {
+  if (value is bool) return {'booleanValue': value};
+  if (value is double) return {'doubleValue': value};
+  if (value is int) return {'integerValue': value.toString()};
+  if (value is Int64) return {'integerValue': value};
+  if (value is String) return {'stringValue': value};
+  if (value is DateTime) return {'timestampValue': value.toIso8601String()};
+  if (value is List) {
+    return {
+      'arrayValue': {'values': value}
+    };
+  }
+  if (value is Map) {
+    return {
+      'mapValue': {'fields': value}
+    };
+  }
+
+  return '';
+}
+
+/// Unpacks a [Value] object recursively depending on its underlying type.
+///
+/// See:
+/// https://pub.dev/documentation/googleapis/latest/googleapis.firestore.v1/Value-class.html
+Object unpackValue(Value packedValue) {
+  Object unpacked;
+
+  // Only one of [packedValue]'s .*Value fields will be set.
+  // The others will be null.
+  unpacked ??= packedValue.booleanValue;
+  unpacked ??= packedValue.doubleValue;
+  unpacked ??= packedValue.integerValue;
+  unpacked ??= packedValue.stringValue;
+  unpacked ??= packedValue.timestampValue;
+  unpacked ??= packedValue.arrayValue?.values?.map(unpackValue)?.toList();
+  if (unpacked != null) return unpacked;
+
+  // If the value is a map value, recurse and create a new map.
+  final newMap = {};
+  packedValue.mapValue?.fields?.forEach((key, value) {
+    newMap[key] = unpackValue(value);
+  });
+
+  return newMap;
+}

--- a/server/pubspec.yaml
+++ b/server/pubspec.yaml
@@ -3,13 +3,14 @@ description: a server to manage and run scheduled rules for DV360 entities
 version: 0.0.1
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   aqueduct: ^3.3.0+1
   googleapis: ^0.55.0
   googleapis_auth: ^0.2.12
   fixnum: ^0.10.11
+  protobuf: ^1.0.1
 
 dev_dependencies:
   test: ^1.0.0

--- a/server/test/firestore_test.dart
+++ b/server/test/firestore_test.dart
@@ -21,10 +21,10 @@ void main() {
   const userId = '1234567890';
   const parent = 'projects/$projectId/databases/$databaseId/documents';
   const ruleResourceName =
-      '$parent/${FirestoreClient.usersCollectionName}/$userId/'
-      '${FirestoreClient.rulesCollectionName}';
+      '$parent/${FirestoreClient.usersName}/$userId/'
+      '${FirestoreClient.rulesName}';
   const userCollectionResourceName =
-      '$parent/${FirestoreClient.usersCollectionName}';
+      '$parent/${FirestoreClient.usersName}';
   const encryptedRefreshToken = 'abc123';
 
   final rule = Rule()

--- a/server/test/firestore_test.dart
+++ b/server/test/firestore_test.dart
@@ -18,6 +18,7 @@ void main() {
   const projectId = 'spreadsheet-dv360-plugin';
   const databaseId = '(default)';
   const ruleName = 'testRule';
+  const documentName = 'testDocument';
   const userId = '1234567890';
   const parent = 'projects/$projectId/databases/$databaseId/documents';
   const ruleResourceName =
@@ -63,7 +64,7 @@ void main() {
   group('Success case: createRule()', () {
     setUp(() async {
       final ruleAsDocument = rule.toDocument();
-      ruleAsDocument.name = ruleName;
+      ruleAsDocument.name = documentName;
 
       mockFirestoreServer.queueResponse(Response.ok(ruleAsDocument.toJson()));
 
@@ -87,8 +88,8 @@ void main() {
       expect(document.toJson(), equals(rule.toDocument().toJson()));
     });
 
-    test('returns the correct rule name', () async {
-      expect(returnedString, equals(ruleName));
+    test('returns the correct document name', () async {
+      expect(returnedString, equals(documentName));
     });
   });
 

--- a/server/test/firestore_test.dart
+++ b/server/test/firestore_test.dart
@@ -1,0 +1,187 @@
+import 'package:aqueduct/aqueduct.dart';
+import 'package:aqueduct_test/aqueduct_test.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:googleapis/firestore/v1.dart' as firestore;
+import 'package:googleapis/discovery/v1.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import 'package:server/proto/rule.pb.dart';
+import 'package:server/service/firestore.dart';
+import 'package:server/utils.dart';
+
+void main() {
+  const mockServerPort = 8002;
+  final mockFirestoreServer = MockHTTPServer(mockServerPort);
+  const url = 'http://localhost:$mockServerPort/';
+
+  const projectId = 'spreadsheet-dv360-plugin';
+  const databaseId = '(default)';
+  const ruleName = 'testRule';
+  const userId = '1234567890';
+  const parent = 'projects/$projectId/databases/$databaseId/documents';
+  const ruleResourceName =
+      '$parent/${FirestoreClient.usersCollectionName}/$userId/'
+      '${FirestoreClient.rulesCollectionName}';
+  const userCollectionResourceName =
+      '$parent/${FirestoreClient.usersCollectionName}';
+  const encryptedRefreshToken = 'abc123';
+
+  final rule = Rule()
+    ..name = ruleName
+    ..action = (Action()
+      ..type = Action_Type.CHANGE_LINE_ITEM_STATUS
+      ..changeLineItemStatusParams = (ChangeLineItemStatusParams()
+        ..lineItemIds.add(Int64(12345))
+        ..advertiserId = Int64(67890)
+        ..status = ChangeLineItemStatusParams_Status.PAUSED))
+    ..schedule = (Schedule()
+      ..type = Schedule_Type.REPEATING
+      ..timezone = 'America/Los_Angeles'
+      ..repeatingParams =
+          (Schedule_RepeatingParams()..cronExpression = '* * * * *'));
+
+  final client = http.Client();
+  final firestoreClient = FirestoreClient(client, projectId, databaseId, url);
+
+  Request request;
+  String returnedString;
+  firestore.Document userDocument;
+
+  setUpAll(() async {
+    await mockFirestoreServer.open();
+  });
+
+  tearDownAll(() async {
+    await mockFirestoreServer.close();
+  });
+
+  tearDown(() async {
+    mockFirestoreServer.clear();
+  });
+
+  group('Success case: createRule()', () {
+    setUp(() async {
+      final ruleAsDocument = rule.toDocument();
+      ruleAsDocument.name = ruleName;
+
+      mockFirestoreServer.queueResponse(Response.ok(ruleAsDocument.toJson()));
+
+      returnedString = await firestoreClient.createRule(userId, rule);
+      request = await mockFirestoreServer.next();
+    });
+
+    test('makes a POST request', () async {
+      expect(request.method, equals('POST'));
+    });
+
+    test('makes a request that goes to the correct path', () async {
+      expect(request.path.string, '/v1/$ruleResourceName');
+    });
+
+    test(
+        'makes a request with a body that contains a Document equivalent '
+        'to the rule', () async {
+      final document = firestore.Document.fromJson(await request.body.decode());
+
+      expect(document.toJson(), equals(rule.toDocument().toJson()));
+    });
+
+    test('returns the correct rule name', () async {
+      expect(returnedString, equals(ruleName));
+    });
+  });
+
+  group('Failure case: createRule()', () {
+    test('throws an ApiRequestError when there is an API error', () async {
+      mockFirestoreServer.queueResponse(Response.notFound());
+
+      Future<void> actual() async =>
+          await firestoreClient.createRule(userId, rule);
+
+      expect(actual, throwsA(const TypeMatcher<ApiRequestError>()));
+    });
+  });
+
+  group('Success case: createUser()', () {
+    setUp(() async {
+      userDocument = firestore.Document()
+        ..name = userId
+        ..fields = {
+          FirestoreClient.encryptedRefreshTokenFieldName: firestore.Value()
+            ..stringValue = encryptedRefreshToken
+        };
+
+      mockFirestoreServer.queueResponse(Response.ok(userDocument.toJson()));
+
+      await firestoreClient.createUser(userId, encryptedRefreshToken);
+      request = await mockFirestoreServer.next();
+    });
+
+    test('makes a POST request', () async {
+      expect(request.method, equals('POST'));
+    });
+
+    test('makes a request that goes to the correct path', () async {
+      expect(request.path.string, '/v1/$userCollectionResourceName');
+    });
+
+    test(
+        'makes a request with a body that contains a Document equivalent '
+        'to the newly created user', () async {
+      final document = firestore.Document.fromJson(await request.body.decode())
+        ..name = userId;
+
+      expect(document.toJson(), equals(userDocument.toJson()));
+    });
+  });
+
+  group('Failure case: createUser()', () {
+    test('throws an ApiRequestError when there is an API error', () async {
+      mockFirestoreServer.queueResponse(Response.notFound());
+
+      Future<void> actual() async =>
+          await firestoreClient.createUser(userId, encryptedRefreshToken);
+
+      expect(actual, throwsA(const TypeMatcher<ApiRequestError>()));
+    });
+  });
+
+  group('Success case: getEncryptedUserRefreshToken()', () {
+    setUp(() async {
+      userDocument = firestore.Document()
+        ..name = userId
+        ..fields = {
+          FirestoreClient.encryptedRefreshTokenFieldName: firestore.Value()
+            ..stringValue = encryptedRefreshToken
+        };
+      mockFirestoreServer.queueResponse(Response.ok(userDocument.toJson()));
+
+      await firestoreClient.getEncryptedUserRefreshToken(userId);
+      request = await mockFirestoreServer.next();
+    });
+
+    test('makes a GET request', () async {
+      expect(request.method, equals('GET'));
+    });
+
+    test('makes a request that goes to the correct path', () async {
+      expect(request.path.string, '/v1/$userCollectionResourceName/$userId');
+    });
+
+    test('Request body is empty', () async {
+      expect(request.body, isEmpty);
+    });
+  });
+
+  group('Failure case: getEncryptedUserRefreshToken()', () {
+    test('throws an ApiRequestError when there is an API error', () async {
+      mockFirestoreServer.queueResponse(Response.notFound());
+
+      Future<void> actual() async =>
+          await firestoreClient.getEncryptedUserRefreshToken(userId);
+
+      expect(actual, throwsA(const TypeMatcher<ApiRequestError>()));
+    });
+  });
+}

--- a/server/test/utils_test.dart
+++ b/server/test/utils_test.dart
@@ -51,11 +51,10 @@ void main() {
 
   group('Rule-Document Conversion:', () {
     test('toDocument() converts a Rule to an equivalent Document', () async {
-      final ruleAsDocument = rule.toDocument();
+      final ruleDocument = rule.toDocument();
 
-      // I haven't overridden [Document.equals()] yet, so currently just
-      // comparing JSONs
-      expect(ruleAsDocument.toJson(), equals(document.toJson()));
+      // TODO(@thu5): Override [Document.equals()] instead of comparing JSONs.
+      expect(ruleDocument.toJson(), equals(document.toJson()));
     });
 
     test('toProto() converts a Document to an equivalent Rule', () async {

--- a/server/test/utils_test.dart
+++ b/server/test/utils_test.dart
@@ -1,0 +1,67 @@
+import 'package:fixnum/fixnum.dart';
+import 'package:googleapis/firestore/v1.dart';
+import 'package:server/proto/rule.pb.dart';
+import 'package:server/utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final rule = Rule()
+    ..name = "My new rule"
+    ..action = (Action()
+      ..type = Action_Type.CHANGE_LINE_ITEM_STATUS
+      ..changeLineItemStatusParams = (ChangeLineItemStatusParams()
+        ..lineItemIds.add(Int64(12345))
+        ..advertiserId = Int64(67890)
+        ..status = ChangeLineItemStatusParams_Status.PAUSED))
+    ..schedule = (Schedule()
+      ..type = Schedule_Type.REPEATING
+      ..timezone = 'America/Los_Angeles'
+      ..repeatingParams =
+          (Schedule_RepeatingParams()..cronExpression = '* * * * *'));
+
+  final document = Document()
+    ..fields = {
+      'name': (Value()..stringValue = 'My new rule'),
+      'action': (Value()
+        ..mapValue = (MapValue()
+          ..fields = {
+            'type': (Value()..stringValue = 'CHANGE_LINE_ITEM_STATUS'),
+            'changeLineItemStatusParams': (Value()
+              ..mapValue = (MapValue()
+                ..fields = {
+                  'lineItemIds': (Value()
+                    ..arrayValue = (ArrayValue()
+                      ..values = [Value()..stringValue = '12345'])),
+                  'advertiserId': (Value()..stringValue = '67890'),
+                  'status': (Value()..stringValue = 'PAUSED'),
+                }))
+          })),
+      'schedule': (Value()
+        ..mapValue = (MapValue()
+          ..fields = {
+            'type': (Value()..stringValue = 'REPEATING'),
+            'timezone': (Value()..stringValue = 'America/Los_Angeles'),
+            'repeatingParams': (Value()
+              ..mapValue = (MapValue()
+                ..fields = {
+                  'cronExpression': Value()..stringValue = '* * * * *',
+                }))
+          }))
+    };
+
+  group('Rule-Document Conversion:', () {
+    test('toDocument() converts a Rule to an equivalent Document', () async {
+      final ruleAsDocument = rule.toDocument();
+
+      // I haven't overridden [Document.equals()] yet, so currently just
+      // comparing JSONs
+      expect(ruleAsDocument.toJson(), equals(document.toJson()));
+    });
+
+    test('toProto() converts a Document to an equivalent Rule', () async {
+      final documentAsRule = document.toProto();
+
+      expect(documentAsRule, equals(rule));
+    });
+  });
+}


### PR DESCRIPTION
This PR adds a wrapper for Firestore and functions to convert between Firestore Documents and protobuf generated Rules. Resolves #87.

Sorry this PR is a little larger. 😅