### PR TITLE
Add ID token validator

### DIFF
--- a/server/config.src.yaml
+++ b/server/config.src.yaml
@@ -4,6 +4,7 @@ projectId: projectid
 databaseId: (default)
 locationId: us-central1
 appEngineService: rules-server
+googleKeysUrl: https://www.googleapis.com/oauth2/v3/certs
 
 displayVideo360:
   baseURL: https://localhost:8001/

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -4,6 +4,7 @@ projectId: $PROJECT_ID
 databaseId: (default)
 locationId: us-central1
 appEngineService: rules-server
+googleKeysUrl: https://www.googleapis.com/oauth2/v3/certs
 
 displayVideo360:
   baseURL: https://displayvideo.googleapis.com/

--- a/server/lib/channel.dart
+++ b/server/lib/channel.dart
@@ -42,6 +42,7 @@ class ServerConfiguration extends Configuration {
   String databaseId;
   String locationId;
   String appEngineService;
+  String googleKeysUrl;
 
   APIConfiguration displayVideo360;
   APIConfiguration firestore;

--- a/server/lib/controller/id_token_validator.dart
+++ b/server/lib/controller/id_token_validator.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:jose/jose.dart';
+import 'package:aqueduct/aqueduct.dart';
+
+/// A middleware controller to validate the user's ID token.
+///
+/// Any request should first be handled by [IdTokenValidator].
+class IdTokenValidator extends Controller {
+  /// The url to Google's public keys in JWK format.
+  final String _keysUrl;
+
+  /// Creates an instance of [IdTokenValidator].
+  IdTokenValidator(
+      {String keysUrl = 'https://www.googleapis.com/oauth2/v3/certs'})
+      : _keysUrl = keysUrl;
+
+  /// Verifies the ID token is valid.
+  ///
+  /// Returns the [request] to the next linked controller upon success. Else,
+  /// returns a 401 Unauthorized response to the user. Throws an [ArgumentError]
+  /// when the Authorization header is missing.
+  @override
+  Future<RequestOrResponse> handle(Request request) async {
+    // The ID token is sent in the `Authorization` header of the request.
+    final authorizationHeader = request.raw.headers.value('Authorization');
+    if (authorizationHeader == null) {
+      throw ArgumentError('Request does not contain an Authorization header');
+    }
+    final encodedIdToken = authorizationHeader.split(' ').last;
+
+    // Decodes the ID token.
+    final jwt = JsonWebToken.unverified(encodedIdToken);
+
+    // Creates a key store and adds Google's public keys.
+    final keyStore = JsonWebKeyStore();
+    keyStore.addKeySetUrl(Uri.parse(_keysUrl));
+
+    // Verifies the ID token.
+    final isVerified = await jwt.verify(keyStore);
+
+    return isVerified ? request : Response.unauthorized();
+  }
+}

--- a/server/pubspec.yaml
+++ b/server/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   fixnum: ^0.10.11
   protobuf: ^1.0.1
   mockito: ^4.1.1
+  jose: ^0.2.1+1
+  mock_request: ^1.0.7
 
 dev_dependencies:
   test: ^1.0.0

--- a/server/test/id_token_validator_test.dart
+++ b/server/test/id_token_validator_test.dart
@@ -1,0 +1,80 @@
+import 'package:aqueduct/aqueduct.dart';
+import 'package:aqueduct_test/aqueduct_test.dart';
+import 'package:jose/jose.dart';
+import 'package:mock_request/mock_request.dart';
+import 'package:test/test.dart';
+
+import 'package:server/controller/id_token_validator.dart';
+
+void main() {
+  // The claims to be used in the ID token.
+  final idTokenClaims = JsonWebTokenClaims.fromJson({
+    'sub': '123',
+  });
+
+  // Creates a random JWK to generate a valid ID token.
+  final jsonWebKey = JsonWebKey.generate('RS256');
+  final jwsBuilder = JsonWebSignatureBuilder();
+  jwsBuilder.jsonContent = idTokenClaims.toJson();
+  jwsBuilder.addRecipient(jsonWebKey);
+  final validIdToken = jwsBuilder.build().toCompactSerialization();
+
+  // Creates a random JWK to generate an invalid ID token.
+  final invalidJsonWebKey = JsonWebKey.generate('RS256');
+  final invalidJwsBuilder = JsonWebSignatureBuilder();
+  invalidJwsBuilder.jsonContent = idTokenClaims.toJson();
+  invalidJwsBuilder.addRecipient(invalidJsonWebKey);
+  final invalidIdToken = invalidJwsBuilder.build().toCompactSerialization();
+
+  // Sets up the mock key server.
+  final jsonWebKeySet = JsonWebKeySet.fromKeys([jsonWebKey]);
+  const mockServerPort = 8004;
+  final mockKeyServer = MockHTTPServer(mockServerPort);
+  const url = 'http://localhost:$mockServerPort';
+
+  // Sets up validator controller.
+  final validator = IdTokenValidator(keysUrl: url);
+
+  // Sets up requests used in testing.
+  final invalidHeadersReq = Request(MockHttpRequest('GET', Uri.parse('/test')));
+  final validReq = Request(MockHttpRequest('GET', Uri.parse('/test'))
+    ..headers.add('Authorization', 'Bearer $validIdToken'));
+  final invalidReq = Request(MockHttpRequest('GET', Uri.parse('/test'))
+    ..headers.add('Authorization', 'Bearer $invalidIdToken'));
+
+  setUpAll(() async {
+    await mockKeyServer.open();
+  });
+
+  tearDownAll(() async {
+    await mockKeyServer.close();
+  });
+
+  tearDown(() async {
+    mockKeyServer.clear();
+  });
+
+  group('handle()', () {
+    setUp(() async {
+      mockKeyServer.queueResponse(Response.ok(jsonWebKeySet.toJson()));
+    });
+
+    test('throws an ArgumentError when headers are invalid', () async {
+      Future<void> actual() async => await validator.handle(invalidHeadersReq);
+
+      expect(actual, throwsA(const TypeMatcher<ArgumentError>()));
+    });
+
+    test('returns the request for a valid ID token', () async {
+      final request = await validator.handle(validReq);
+
+      expect(request, equals(validReq));
+    });
+
+    test('returns 401 Unauthorized response for an invalid ID token', () async {
+      final response = await validator.handle(invalidReq);
+
+      expect((response as Response).statusCode, equals(401));
+    });
+  });
+}


### PR DESCRIPTION
This PR adds a middleware controller to verify the integrity of the ID token. If verified, it returns the request to the next controller. Otherwise, an Unauthorized response is immediately sent to the user. Closes #100.