### PR TITLE
Add method to obtain refresh and identity tokens on client side

### DIFF
--- a/lib/src/private_keys.dart
+++ b/lib/src/private_keys.dart
@@ -3,3 +3,4 @@
 
 var apiKey = 'API_KEY';
 var clientID = 'CLIENT_ID';
+var clientSecret = 'CLIENT_SECRET';


### PR DESCRIPTION
This PR adds a method to `GoogleApiDart` to first obtain permission from the user for offline access, and then gets the refresh and identity tokens. Resolves #113.