### PR TITLE
Add scope to proto

### DIFF
--- a/rule.proto
+++ b/rule.proto
@@ -18,6 +18,9 @@ message Rule {
 
   // optional
   optional Condition condition = 5;
+
+  // required
+  optional Scope scope = 6;
 }
 
 // A message representing the action applied to a DV360 entity.
@@ -40,14 +43,6 @@ message Action {
 
 // The action parameters to change line items' status.
 message ChangeLineItemStatusParams {
-  // required
-  // The ID of line items to which the action applies.
-  repeated int64 line_item_ids = 1;
-
-  // required
-  // The ID of advertiser to which the line items belong to.
-  optional int64 advertiser_id = 2;
-
   enum Status {
     UNSPECIFIED_STATUS = 0;
     ACTIVE = 1;
@@ -112,5 +107,34 @@ message Condition {
 
   // required
   // The value which the metric will be compared against.
-  optional int32 value = 3;
+  optional double value = 3;
+}
+
+// A message that represents the target entities for a rule.
+message Scope {
+  enum Type {
+    UNSPECIFIED_TYPE = 0;
+    LINE_ITEM_TYPE = 1;
+  }
+
+  // required
+  // The type of scope.
+  optional Type type = 1;
+
+  // required
+  // The parameters used for each type of scope.
+  oneof params {
+    LineItemScopeParams line_item_scope_params = 2;
+  }
+}
+
+// A message representing the parameters for line item scopes.
+message LineItemScopeParams {
+  // required
+  // The ID of line items.
+  repeated int64 line_item_ids = 1;
+
+  // required
+  // The ID of advertiser to which the line items belong to.
+  optional int64 advertiser_id = 2;
 }

--- a/server/lib/model/rule.dart
+++ b/server/lib/model/rule.dart
@@ -1,12 +1,17 @@
 import '../proto/rule.pb.dart' as proto;
 import 'action.dart';
+import 'scope.dart';
 
 /// A class that represents a rule to manipulate DV360 entities.
 class Rule {
   /// An [Action] instance that manipulates DV360 entities.
   final Action action;
 
+  /// The [Scope] for the rule.
+  final Scope scope;
+
   /// Creates a [Rule] from a [proto.Rule].
   Rule.fromProto(proto.Rule protoRule)
-      : action = Action.getActionFromProto(protoRule.action);
+      : action = Action.getActionFromProto(protoRule.action),
+        scope = Scope.getScopeFromProto(protoRule.scope);
 }

--- a/server/lib/model/scope.dart
+++ b/server/lib/model/scope.dart
@@ -1,0 +1,41 @@
+import 'package:fixnum/fixnum.dart';
+
+import '../proto/rule.pb.dart' as proto;
+
+/// A class that represents the target entities for the rule.
+class Scope {
+  /// A list of target DV360 entities.
+  List<Target> targets = [];
+
+  /// Creates an instance of a class that implements [Scope] from a proto.
+  ///
+  /// Throws an [UnsupportedError] if the proto's scope type is unspecified.
+  static Scope getScopeFromProto(proto.Scope scope) {
+    switch (scope.type) {
+      case proto.Scope_Type.LINE_ITEM_TYPE:
+        final scopeModel = Scope();
+        final advertiserId = scope.lineItemScopeParams.advertiserId;
+        for (final lineItemId in scope.lineItemScopeParams.lineItemIds) {
+          scopeModel.targets.add(LineItemTarget(lineItemId, advertiserId));
+        }
+        return scopeModel;
+      default:
+        throw UnsupportedError('${scope.type} is not a supported scope type.');
+    }
+  }
+}
+
+/// An interface to represent a target DV360 entity.
+abstract class Target {}
+
+/// A class to represent a DV360 line item target.
+class LineItemTarget implements Target {
+  /// The line item ID.
+  Int64 lineItemId;
+
+  /// The advertiser ID of the line item.
+  Int64 advertiserId;
+
+  /// Creates an instance of [LineItemTarget].
+  LineItemTarget(this.lineItemId, this.advertiserId);
+}

--- a/server/lib/service/dv360.dart
+++ b/server/lib/service/dv360.dart
@@ -29,6 +29,8 @@ class DisplayVideo360Client {
 
   /// Runs the rule to manipulate DV360 line items.
   Future<void> run(Rule rule) async {
-    await rule.action.run(this);
+    for (final target in rule.scope.targets) {
+      await rule.action.run(this, target);
+    }
   }
 }

--- a/server/test/action_test.dart
+++ b/server/test/action_test.dart
@@ -3,17 +3,20 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'package:server/model/action.dart';
+import 'package:server/model/scope.dart';
 import 'package:server/proto/rule.pb.dart' as proto;
 import 'package:server/service/dv360.dart';
 
 class MockDisplayVideo360Client extends Mock implements DisplayVideo360Client {}
 
 void main() {
+  final lineItemId = Int64(12345);
+  final advertiserId = Int64(67890);
+  final target = LineItemTarget(lineItemId, advertiserId);
+
   final validActionProto = proto.Action()
     ..type = proto.Action_Type.CHANGE_LINE_ITEM_STATUS
     ..changeLineItemStatusParams = (proto.ChangeLineItemStatusParams()
-      ..lineItemIds.add(Int64(34787229))
-      ..advertiserId = Int64(3849739)
       ..status = proto.ChangeLineItemStatusParams_Status.PAUSED);
 
   final unspecifiedActionProto = proto.Action()
@@ -43,15 +46,11 @@ void main() {
     });
 
     test('run() changes the line item status using the client', () async {
-      final advertiserId =
-          validActionProto.changeLineItemStatusParams.advertiserId;
-      final lineItemId =
-          validActionProto.changeLineItemStatusParams.lineItemIds[0];
       final status = 'ENTITY_STATUS_'
           '${validActionProto.changeLineItemStatusParams.status.name}';
       final action = Action.getActionFromProto(validActionProto);
 
-      await action.run(mockClient);
+      await action.run(mockClient, target);
 
       verify(mockClient.changeLineItemStatus(advertiserId, lineItemId, status));
     });

--- a/server/test/firestore_test.dart
+++ b/server/test/firestore_test.dart
@@ -6,7 +6,7 @@ import 'package:googleapis/discovery/v1.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
-import 'package:server/proto/rule.pb.dart';
+import 'package:server/proto/rule.pb.dart' as proto;
 import 'package:server/service/firestore.dart';
 import 'package:server/utils.dart';
 
@@ -21,26 +21,27 @@ void main() {
   const documentName = 'testDocument';
   const userId = '1234567890';
   const parent = 'projects/$projectId/databases/$databaseId/documents';
-  const ruleResourceName =
-      '$parent/${FirestoreClient.usersName}/$userId/'
+  const ruleResourceName = '$parent/${FirestoreClient.usersName}/$userId/'
       '${FirestoreClient.rulesName}';
-  const userCollectionResourceName =
-      '$parent/${FirestoreClient.usersName}';
+  const userCollectionResourceName = '$parent/${FirestoreClient.usersName}';
   const encryptedRefreshToken = 'abc123';
 
-  final rule = Rule()
+  final rule = proto.Rule()
     ..name = ruleName
-    ..action = (Action()
-      ..type = Action_Type.CHANGE_LINE_ITEM_STATUS
-      ..changeLineItemStatusParams = (ChangeLineItemStatusParams()
-        ..lineItemIds.add(Int64(12345))
-        ..advertiserId = Int64(67890)
-        ..status = ChangeLineItemStatusParams_Status.PAUSED))
-    ..schedule = (Schedule()
-      ..type = Schedule_Type.REPEATING
+    ..action = (proto.Action()
+      ..type = proto.Action_Type.CHANGE_LINE_ITEM_STATUS
+      ..changeLineItemStatusParams = (proto.ChangeLineItemStatusParams()
+        ..status = proto.ChangeLineItemStatusParams_Status.PAUSED))
+    ..schedule = (proto.Schedule()
+      ..type = proto.Schedule_Type.REPEATING
       ..timezone = 'America/Los_Angeles'
       ..repeatingParams =
-          (Schedule_RepeatingParams()..cronExpression = '* * * * *'));
+          (proto.Schedule_RepeatingParams()..cronExpression = '* * * * *'))
+    ..scope = (proto.Scope()
+      ..type = proto.Scope_Type.LINE_ITEM_TYPE
+      ..lineItemScopeParams = (proto.LineItemScopeParams()
+        ..lineItemIds.add(Int64(12345))
+        ..advertiserId = Int64(67890)));
 
   final client = http.Client();
   final firestoreClient = FirestoreClient(client, projectId, databaseId, url);

--- a/server/test/rule_controller_test.dart
+++ b/server/test/rule_controller_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 
 import 'package:server/controller/rule_controller.dart';
 import 'package:server/proto/create_rule_request.pb.dart';
-import 'package:server/proto/rule.pb.dart';
+import 'package:server/proto/rule.pb.dart' as proto;
 import 'package:server/service/firestore.dart';
 import 'package:server/service/scheduler.dart';
 
@@ -19,21 +19,24 @@ Future<void> main() async {
   const userId = '123abc';
   const ruleId = 'abc123';
   Response response;
-  Rule ruleWithId;
+  proto.Rule ruleWithId;
 
-  final rule = Rule()
+  final rule = proto.Rule()
     ..name = 'My new rule'
-    ..action = (Action()
-      ..type = Action_Type.CHANGE_LINE_ITEM_STATUS
-      ..changeLineItemStatusParams = (ChangeLineItemStatusParams()
-        ..lineItemIds.add(Int64(12345))
-        ..advertiserId = Int64(67890)
-        ..status = ChangeLineItemStatusParams_Status.PAUSED))
-    ..schedule = (Schedule()
-      ..type = Schedule_Type.REPEATING
+    ..action = (proto.Action()
+      ..type = proto.Action_Type.CHANGE_LINE_ITEM_STATUS
+      ..changeLineItemStatusParams = (proto.ChangeLineItemStatusParams()
+        ..status = proto.ChangeLineItemStatusParams_Status.PAUSED))
+    ..schedule = (proto.Schedule()
+      ..type = proto.Schedule_Type.REPEATING
       ..timezone = 'America/Los_Angeles'
       ..repeatingParams =
-          (Schedule_RepeatingParams()..cronExpression = '* * * * *'));
+      (proto.Schedule_RepeatingParams()..cronExpression = '* * * * *'))
+    ..scope = (proto.Scope()
+      ..type = proto.Scope_Type.LINE_ITEM_TYPE
+      ..lineItemScopeParams = (proto.LineItemScopeParams()
+        ..lineItemIds.add(Int64(12345))
+        ..advertiserId = Int64(67890)));
   final createRuleRequest = CreateRuleRequest()..rule = rule;
 
   // Sets up the mock Firestore client, Scheduler client and rule controller.

--- a/server/test/rule_controller_test.dart
+++ b/server/test/rule_controller_test.dart
@@ -31,7 +31,7 @@ Future<void> main() async {
       ..type = proto.Schedule_Type.REPEATING
       ..timezone = 'America/Los_Angeles'
       ..repeatingParams =
-      (proto.Schedule_RepeatingParams()..cronExpression = '* * * * *'))
+          (proto.Schedule_RepeatingParams()..cronExpression = '* * * * *'))
     ..scope = (proto.Scope()
       ..type = proto.Scope_Type.LINE_ITEM_TYPE
       ..lineItemScopeParams = (proto.LineItemScopeParams()
@@ -70,7 +70,8 @@ Future<void> main() async {
       verify(mockFirestoreClient.createRule(userId, ruleWithId));
     });
 
-    test('calls schedulerClient.scheduleRule() with correct arguments', () async {
+    test('calls schedulerClient.scheduleRule() with correct arguments',
+        () async {
       verify(mockSchedulerClient.scheduleRule(userId, ruleWithId));
     });
 

--- a/server/test/run_rule_controller_test.dart
+++ b/server/test/run_rule_controller_test.dart
@@ -37,7 +37,7 @@ Future<void> main() async {
       ..type = proto.Schedule_Type.REPEATING
       ..timezone = 'America/Los_Angeles'
       ..repeatingParams =
-      (proto.Schedule_RepeatingParams()..cronExpression = '* * * * *'))
+          (proto.Schedule_RepeatingParams()..cronExpression = '* * * * *'))
     ..scope = (proto.Scope()
       ..type = proto.Scope_Type.LINE_ITEM_TYPE
       ..lineItemScopeParams = (proto.LineItemScopeParams()

--- a/server/test/run_rule_controller_test.dart
+++ b/server/test/run_rule_controller_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 import 'package:server/controller/run_rule_controller.dart';
 import 'package:server/proto/scheduled_rule.pb.dart';
-import 'package:server/proto/rule.pb.dart';
+import 'package:server/proto/rule.pb.dart' as proto;
 import 'package:server/service/firestore.dart';
 import 'package:server/service/google_api.dart';
 import 'package:server/utils.dart';
@@ -26,20 +26,23 @@ Future<void> main() async {
   const userId = '123abc';
   const ruleId = 'abc123';
 
-  final rule = Rule()
+  final rule = proto.Rule()
     ..name = 'test'
     ..id = ruleId
-    ..action = (Action()
-      ..type = Action_Type.CHANGE_LINE_ITEM_STATUS
-      ..changeLineItemStatusParams = (ChangeLineItemStatusParams()
-        ..lineItemIds.add(Int64(12345))
-        ..advertiserId = Int64(67890)
-        ..status = ChangeLineItemStatusParams_Status.PAUSED))
-    ..schedule = (Schedule()
-      ..type = Schedule_Type.REPEATING
+    ..action = (proto.Action()
+      ..type = proto.Action_Type.CHANGE_LINE_ITEM_STATUS
+      ..changeLineItemStatusParams = (proto.ChangeLineItemStatusParams()
+        ..status = proto.ChangeLineItemStatusParams_Status.PAUSED))
+    ..schedule = (proto.Schedule()
+      ..type = proto.Schedule_Type.REPEATING
       ..timezone = 'America/Los_Angeles'
       ..repeatingParams =
-          (Schedule_RepeatingParams()..cronExpression = '* * * * *'));
+      (proto.Schedule_RepeatingParams()..cronExpression = '* * * * *'))
+    ..scope = (proto.Scope()
+      ..type = proto.Scope_Type.LINE_ITEM_TYPE
+      ..lineItemScopeParams = (proto.LineItemScopeParams()
+        ..lineItemIds.add(Int64(12345))
+        ..advertiserId = Int64(67890)));
 
   final scheduledRule = ScheduledRule()
     ..ruleId = ruleId

--- a/server/test/scheduler_test.dart
+++ b/server/test/scheduler_test.dart
@@ -35,7 +35,7 @@ void main() {
       ..type = proto.Schedule_Type.REPEATING
       ..timezone = 'America/Los_Angeles'
       ..repeatingParams =
-      (proto.Schedule_RepeatingParams()..cronExpression = '* * * * *'))
+          (proto.Schedule_RepeatingParams()..cronExpression = '* * * * *'))
     ..scope = (proto.Scope()
       ..type = proto.Scope_Type.LINE_ITEM_TYPE
       ..lineItemScopeParams = (proto.LineItemScopeParams()

--- a/server/test/scheduler_test.dart
+++ b/server/test/scheduler_test.dart
@@ -5,7 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
 import 'package:server/proto/scheduled_rule.pb.dart';
-import 'package:server/proto/rule.pb.dart';
+import 'package:server/proto/rule.pb.dart' as proto;
 import 'package:server/server.dart';
 import 'package:server/service/scheduler.dart';
 
@@ -24,25 +24,28 @@ void main() {
   Request request;
   Job job;
 
-  final lineItemStatusRule = Rule()
+  final lineItemStatusRule = proto.Rule()
     ..name = 'My new rule'
     ..id = '123'
-    ..action = (Action()
-      ..type = Action_Type.CHANGE_LINE_ITEM_STATUS
-      ..changeLineItemStatusParams = (ChangeLineItemStatusParams()
-        ..lineItemIds.add(Int64(12345))
-        ..advertiserId = Int64(67890)
-        ..status = ChangeLineItemStatusParams_Status.PAUSED))
-    ..schedule = (Schedule()
-      ..type = Schedule_Type.REPEATING
+    ..action = (proto.Action()
+      ..type = proto.Action_Type.CHANGE_LINE_ITEM_STATUS
+      ..changeLineItemStatusParams = (proto.ChangeLineItemStatusParams()
+        ..status = proto.ChangeLineItemStatusParams_Status.PAUSED))
+    ..schedule = (proto.Schedule()
+      ..type = proto.Schedule_Type.REPEATING
       ..timezone = 'America/Los_Angeles'
       ..repeatingParams =
-          (Schedule_RepeatingParams()..cronExpression = '* * * * *'));
+      (proto.Schedule_RepeatingParams()..cronExpression = '* * * * *'))
+    ..scope = (proto.Scope()
+      ..type = proto.Scope_Type.LINE_ITEM_TYPE
+      ..lineItemScopeParams = (proto.LineItemScopeParams()
+        ..lineItemIds.add(Int64(12345))
+        ..advertiserId = Int64(67890)));
 
-  final unspecifiedRule = Rule()
+  final unspecifiedRule = proto.Rule()
     ..name = 'My new rule'
     ..id = '123'
-    ..action = (Action()..type = Action_Type.UNSPECIFIED_TYPE);
+    ..action = (proto.Action()..type = proto.Action_Type.UNSPECIFIED_TYPE);
 
   setUpAll(() async {
     await mockSchedulerServer.open();

--- a/server/test/utils_test.dart
+++ b/server/test/utils_test.dart
@@ -2,24 +2,27 @@ import 'package:encrypt/encrypt.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:jose/jose.dart';
-import 'package:server/proto/rule.pb.dart';
+import 'package:server/proto/rule.pb.dart' as proto;
 import 'package:server/utils.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final rule = Rule()
+  final rule = proto.Rule()
     ..name = 'My new rule'
-    ..action = (Action()
-      ..type = Action_Type.CHANGE_LINE_ITEM_STATUS
-      ..changeLineItemStatusParams = (ChangeLineItemStatusParams()
-        ..lineItemIds.add(Int64(12345))
-        ..advertiserId = Int64(67890)
-        ..status = ChangeLineItemStatusParams_Status.PAUSED))
-    ..schedule = (Schedule()
-      ..type = Schedule_Type.REPEATING
+    ..action = (proto.Action()
+      ..type = proto.Action_Type.CHANGE_LINE_ITEM_STATUS
+      ..changeLineItemStatusParams = (proto.ChangeLineItemStatusParams()
+        ..status = proto.ChangeLineItemStatusParams_Status.PAUSED))
+    ..schedule = (proto.Schedule()
+      ..type = proto.Schedule_Type.REPEATING
       ..timezone = 'America/Los_Angeles'
       ..repeatingParams =
-          (Schedule_RepeatingParams()..cronExpression = '* * * * *'));
+          (proto.Schedule_RepeatingParams()..cronExpression = '* * * * *'))
+    ..scope = (proto.Scope()
+      ..type = proto.Scope_Type.LINE_ITEM_TYPE
+      ..lineItemScopeParams = (proto.LineItemScopeParams()
+        ..lineItemIds.add(Int64(12345))
+        ..advertiserId = Int64(67890)));
 
   final document = Document()
     ..fields = {
@@ -31,10 +34,6 @@ void main() {
             'changeLineItemStatusParams': (Value()
               ..mapValue = (MapValue()
                 ..fields = {
-                  'lineItemIds': (Value()
-                    ..arrayValue = (ArrayValue()
-                      ..values = [Value()..stringValue = '12345'])),
-                  'advertiserId': (Value()..stringValue = '67890'),
                   'status': (Value()..stringValue = 'PAUSED'),
                 }))
           })),
@@ -47,6 +46,19 @@ void main() {
               ..mapValue = (MapValue()
                 ..fields = {
                   'cronExpression': Value()..stringValue = '* * * * *',
+                }))
+          })),
+      'scope': (Value()
+        ..mapValue = (MapValue()
+          ..fields = {
+            'type': (Value()..stringValue = 'LINE_ITEM_TYPE'),
+            'lineItemScopeParams': (Value()
+              ..mapValue = (MapValue()
+                ..fields = {
+                  'lineItemIds': (Value()
+                    ..arrayValue = (ArrayValue()
+                      ..values = [Value()..stringValue = '12345'])),
+                  'advertiserId': (Value()..stringValue = '67890'),
                 }))
           }))
     };


### PR DESCRIPTION
This PR adds a Scope message to `rule.proto` so that the scope of the rule is decoupled from the action. The reason for this change is to allow conditions to also access scope data without having to reach into an action. Closes #116.

Tests will be added later (#118).