### PR TITLE
Set up run history

### DIFF
--- a/server/lib/controller/run_rule_controller.dart
+++ b/server/lib/controller/run_rule_controller.dart
@@ -57,10 +57,11 @@ class RunRuleController extends ResourceController {
     final userClient = await _googleApi.getUserAccountClient(refreshToken);
 
     // Creates a DV360 client using the user's authenticated client.
-    final dv360 = DisplayVideo360Client(userClient, _dv360BaseUrl);
+    final dv360 =
+        DisplayVideo360Client(userClient, _firestoreClient, _dv360BaseUrl);
 
     // Runs the rule using the DV360 client.
-    await dv360.run(rule);
+    await dv360.run(rule, userId, ruleId);
 
     return Response.ok({});
   }

--- a/server/lib/service/dv360.dart
+++ b/server/lib/service/dv360.dart
@@ -3,9 +3,9 @@ import 'dart:async';
 import 'package:fixnum/fixnum.dart';
 import 'package:googleapis/displayvideo/v1.dart';
 import 'package:http/http.dart';
-import 'package:server/service/firestore.dart';
 
 import '../model/rule.dart';
+import '../service/firestore.dart';
 
 /// A class that wraps around Display & Video 360.
 class DisplayVideo360Client {
@@ -37,13 +37,11 @@ class DisplayVideo360Client {
       await rule.action.run(this);
     } on ApiRequestError catch (e) {
       // If there is an API error, return the message returned by the API.
-      await _firestoreClient.addRun(userId, ruleId,
+      return await _firestoreClient.addRun(userId, ruleId,
           isSuccess: false, message: e.message);
-      return;
     } catch (e) {
       // If there is another kind of exception, do not include the message.
-      await _firestoreClient.addRun(userId, ruleId, isSuccess: false);
-      return;
+      return await _firestoreClient.addRun(userId, ruleId, isSuccess: false);
     }
     // Logs the successful run of the rule.
     await _firestoreClient.addRun(userId, ruleId, isSuccess: true);

--- a/server/lib/service/dv360.dart
+++ b/server/lib/service/dv360.dart
@@ -37,13 +37,13 @@ class DisplayVideo360Client {
       await rule.action.run(this);
     } on ApiRequestError catch (e) {
       // If there is an API error, return the message returned by the API.
-      return await _firestoreClient.addRun(userId, ruleId,
-          isSuccess: false, message: e.message);
+      return await _firestoreClient.logRunHistory(userId, ruleId, false,
+          message: e.message);
     } catch (e) {
       // If there is another kind of exception, do not include the message.
-      return await _firestoreClient.addRun(userId, ruleId, isSuccess: false);
+      return await _firestoreClient.logRunHistory(userId, ruleId, false);
     }
     // Logs the successful run of the rule.
-    await _firestoreClient.addRun(userId, ruleId, isSuccess: true);
+    await _firestoreClient.logRunHistory(userId, ruleId, true);
   }
 }

--- a/server/lib/service/dv360.dart
+++ b/server/lib/service/dv360.dart
@@ -41,7 +41,13 @@ class DisplayVideo360Client {
           message: e.message);
     } catch (e) {
       // If there is another kind of exception, do not include the message.
-      return await _firestoreClient.logRunHistory(userId, ruleId, false);
+      //
+      // The messages we log should be user-friendly, actionable and
+      // understandable. We can expect this for DV360 API error messages, but
+      // probably not for lower level exception messages. Also, there might be
+      // security issues if we just directly report the raw exception messages.
+      return await _firestoreClient.logRunHistory(userId, ruleId, false,
+          message: 'Internal error encountered');
     }
     // Logs the successful run of the rule.
     await _firestoreClient.logRunHistory(userId, ruleId, true);

--- a/server/lib/service/dv360.dart
+++ b/server/lib/service/dv360.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:fixnum/fixnum.dart';
 import 'package:googleapis/displayvideo/v1.dart';
 import 'package:http/http.dart';
+import 'package:server/service/firestore.dart';
 
 import '../model/rule.dart';
 
@@ -11,8 +12,11 @@ class DisplayVideo360Client {
   /// The DV360 API.
   final DisplayvideoApi _api;
 
+  /// The Firestore client.
+  final FirestoreClient _firestoreClient;
+
   /// Creates an instance of [DisplayVideo360Client].
-  DisplayVideo360Client(Client client, String baseUrl)
+  DisplayVideo360Client(Client client, this._firestoreClient, String baseUrl)
       : _api = DisplayvideoApi(client, rootUrl: baseUrl);
 
   /// Changes the entity status of the line item to [status].
@@ -27,8 +31,21 @@ class DisplayVideo360Client {
         updateMask: 'entityStatus');
   }
 
-  /// Runs the rule to manipulate DV360 line items.
-  Future<void> run(Rule rule) async {
-    await rule.action.run(this);
+  /// Runs the rule to manipulate DV360 line items and logs the result.
+  Future<void> run(Rule rule, String userId, String ruleId) async {
+    try {
+      await rule.action.run(this);
+    } on ApiRequestError catch (e) {
+      // If there is an API error, return the message returned by the API.
+      await _firestoreClient.addRun(userId, ruleId,
+          isSuccess: false, message: e.message);
+      return;
+    } catch (e) {
+      // If there is another kind of exception, do not include the message.
+      await _firestoreClient.addRun(userId, ruleId, isSuccess: false);
+      return;
+    }
+    // Logs the successful run of the rule.
+    await _firestoreClient.addRun(userId, ruleId, isSuccess: true);
   }
 }

--- a/server/lib/service/firestore.dart
+++ b/server/lib/service/firestore.dart
@@ -14,7 +14,7 @@ class FirestoreClient {
   static const rulesName = 'rules';
 
   /// The name of the collection of the run history in Firestore.
-  static const runHistoryName = 'runs';
+  static const runHistoryName = 'runHistory';
 
   /// The name of the encrypted refresh token field in Firestore.
   static const encryptedRefreshTokenFieldName = 'encryptedRefreshToken';
@@ -73,8 +73,8 @@ class FirestoreClient {
   /// See: https://developers.google.com/identity/protocols/oauth2/openid-connect#an-id-tokens-payload
   ///
   /// Throws an [ApiRequestError] if Firestore API returns an error.
-  Future<void> addRun(String userId, String ruleId,
-      {@required bool isSuccess, String message = ''}) async {
+  Future<void> logRunHistory(String userId, String ruleId, bool isSuccess,
+      {String message = ''}) async {
     final document = Document()
       ..fields = {
         'timestamp': Value()

--- a/server/lib/service/firestore.dart
+++ b/server/lib/service/firestore.dart
@@ -1,5 +1,6 @@
 import 'package:googleapis/firestore/v1.dart';
 import 'package:http/http.dart';
+import 'package:meta/meta.dart';
 
 import '../proto/rule.pb.dart';
 import '../utils.dart';
@@ -11,6 +12,9 @@ class FirestoreClient {
 
   /// The name of the collection of rules in Firestore.
   static const rulesName = 'rules';
+
+  /// The name of the collection of the run history in Firestore.
+  static const runHistoryName = 'runs';
 
   /// The name of the encrypted refresh token field in Firestore.
   static const encryptedRefreshTokenFieldName = 'encryptedRefreshToken';
@@ -60,6 +64,29 @@ class FirestoreClient {
       usersName,
       document,
       documentId: userId,
+    );
+  }
+
+  /// Logs [isSuccess] and optional [message] of a performed rule with [ruleId].
+  ///
+  /// The [userId] is the `sub` claim of the user's Google ID token.
+  /// See: https://developers.google.com/identity/protocols/oauth2/openid-connect#an-id-tokens-payload
+  ///
+  /// Throws an [ApiRequestError] if Firestore API returns an error.
+  Future<void> addRun(String userId, String ruleId,
+      {@required bool isSuccess, String message = ''}) async {
+    final document = Document()
+      ..fields = {
+        'timestamp': Value()
+          ..timestampValue = DateTime.now().toUtc().toIso8601String(),
+        'success': Value()..booleanValue = isSuccess,
+        'message': Value()..stringValue = message
+      };
+
+    await _addDocument(
+      '/$usersName/$userId/$rulesName/$ruleId',
+      runHistoryName,
+      document,
     );
   }
 

--- a/server/test/dv360_test.dart
+++ b/server/test/dv360_test.dart
@@ -3,9 +3,13 @@ import 'package:googleapis/displayvideo/v1.dart';
 import 'package:test/test.dart';
 import 'package:aqueduct_test/aqueduct_test.dart';
 import 'package:http/http.dart' as http;
+import 'package:mockito/mockito.dart';
 
 import 'package:server/server.dart';
 import 'package:server/service/dv360.dart';
+import 'package:server/service/firestore.dart';
+
+class MockFirestoreClient extends Mock implements FirestoreClient {}
 
 void main() {
   const mockServerPort = 8001;
@@ -18,12 +22,13 @@ void main() {
 
   final client = http.Client();
   DisplayVideo360Client displayVideo360;
+  final mockFirestoreClient = MockFirestoreClient();
 
   Request request;
 
   setUpAll(() async {
     await mockDisplayVideo360Server.open();
-    displayVideo360 = DisplayVideo360Client(client, url);
+    displayVideo360 = DisplayVideo360Client(client, mockFirestoreClient, url);
   });
 
   tearDownAll(() async {
@@ -54,8 +59,7 @@ void main() {
 
     test(
         'makes a request with a body that contains a line item '
-            'with the correct entityStatus',
-        () async {
+        'with the correct entityStatus', () async {
       final lineItem = LineItem.fromJson(await request.body.decode());
 
       expect(lineItem.entityStatus, equals(status));

--- a/server/test/firestore_test.dart
+++ b/server/test/firestore_test.dart
@@ -21,11 +21,9 @@ void main() {
   const documentName = 'testDocument';
   const userId = '1234567890';
   const parent = 'projects/$projectId/databases/$databaseId/documents';
-  const ruleResourceName =
-      '$parent/${FirestoreClient.usersName}/$userId/'
+  const ruleResourceName = '$parent/${FirestoreClient.usersName}/$userId/'
       '${FirestoreClient.rulesName}';
-  const userCollectionResourceName =
-      '$parent/${FirestoreClient.usersName}';
+  const userCollectionResourceName = '$parent/${FirestoreClient.usersName}';
   const encryptedRefreshToken = 'abc123';
 
   final rule = Rule()


### PR DESCRIPTION
This PR adds a method to FirestoreClient to add the run history, and modifies DisplayVideo360Client's `run()` in order to log the performed rule. Resolves #122.

Will add tests later (#124).