### PR TITLE
Move button to rule component and use session storage for ID token

### DIFF
--- a/lib/src/rule_component.dart
+++ b/lib/src/rule_component.dart
@@ -1,10 +1,13 @@
+import 'dart:html';
+
 import 'package:angular/angular.dart';
+import 'package:dv360_excel_plugin/src/service/rule_service.dart';
 
 import 'data_model/rule.pb.dart';
 import 'rule_creator_component.dart';
 import 'rule_detail_component.dart';
-import 'rule_creator_component.dart';
 import 'rule_list_component.dart';
+import 'service/credential_service.dart';
 
 enum View {
   listView,
@@ -22,10 +25,21 @@ enum View {
     RuleDetailComponent,
   ],
   exports: [View],
+  providers: [ClassProvider(RuleService), ClassProvider(CredentialService)],
 )
 class RuleComponent {
+  final CredentialService _credentialService;
+  final RuleService _ruleService;
+
   View view = View.listView;
   Rule detailedRule;
+
+  // Stores and retrieves the ID token from session storage.
+  String get idToken => window.sessionStorage['idToken'];
+  set idToken(String value) => window.sessionStorage['idToken'] = value;
+  bool get hasIdToken => window.sessionStorage.containsKey('idToken');
+
+  RuleComponent(this._credentialService, this._ruleService);
 
   void toCreateView() {
     view = View.createView;
@@ -42,5 +56,13 @@ class RuleComponent {
   Future<void> changeDetailedRule(Rule rule) async {
     detailedRule = rule;
     toDetailView();
+  }
+
+  Future<void> createUser() async {
+    final tokens = await _credentialService.obtainTokens();
+    final refreshToken = tokens['refresh_token'];
+    idToken = tokens['id_token'];
+
+    await _ruleService.createUser(idToken, refreshToken);
   }
 }

--- a/lib/src/rule_component.html
+++ b/lib/src/rule_component.html
@@ -1,7 +1,9 @@
 <div class="mb-3" *ngIf="view == View.listView">
     <div class="flex-column">
         <rule-list (detailedRule)="changeDetailedRule($event)" class="mb-5"></rule-list>
-        <button type="button" (click)="toCreateView()" class="mt-3 btn btn-success">Create Rule</button>
+
+        <button *ngIf="!hasIdToken" class="btn btn-primary" (click)="createUser()">Grant Offline Access</button>
+        <button *ngIf="hasIdToken" type="button" (click)="toCreateView()" class="mt-3 btn btn-success">Create Rule</button>
     </div>
 </div>
 <div *ngIf="view == View.createView">

--- a/lib/src/rule_component.html
+++ b/lib/src/rule_component.html
@@ -1,7 +1,6 @@
 <div class="mb-3" *ngIf="view == View.listView">
     <div class="flex-column">
         <rule-list (detailedRule)="changeDetailedRule($event)" class="mb-5"></rule-list>
-
         <button *ngIf="!hasIdToken" class="btn btn-primary" (click)="createUser()">Grant Offline Access</button>
         <button *ngIf="hasIdToken" type="button" (click)="toCreateView()" class="mt-3 btn btn-success">Create Rule</button>
     </div>

--- a/lib/src/rule_creator_component.dart
+++ b/lib/src/rule_creator_component.dart
@@ -32,11 +32,10 @@ class RuleCreatorComponent {
   final RuleService _ruleService;
   final CredentialService _credentialService;
 
-  // Stores and retrieves the ID token from local storage.
-  // TODO(@thu5): Use HttpOnly cookies instead of local storage.
-  String get idToken => window.localStorage['idToken'];
-  set idToken(String value) => window.localStorage['idToken'] = value;
-  bool get hasIdToken => window.localStorage.containsKey('idToken');
+  // Stores and retrieves the ID token from session storage.
+  String get idToken => window.sessionStorage['idToken'];
+  set idToken(String value) => window.sessionStorage['idToken'] = value;
+  bool get hasIdToken => window.sessionStorage.containsKey('idToken');
 
   // Rule details and scope input.
   String name;
@@ -116,15 +115,6 @@ class RuleCreatorComponent {
   RuleCreatorComponent(this._ruleService, this._credentialService) {
     initializeTimeZones();
     timeZoneDatabase.locations.keys.forEach((e) => timezones.add(e));
-  }
-
-  // TODO(@thu5): Move user creation logic outside this component.
-  Future<void> createUser() async {
-    final tokens = await _credentialService.obtainTokens();
-    final refreshToken = tokens['refresh_token'];
-    idToken = tokens['id_token'];
-
-    await _ruleService.createUser(idToken, refreshToken);
   }
 
   Future<void> onSubmit() async {

--- a/lib/src/rule_creator_component.html
+++ b/lib/src/rule_creator_component.html
@@ -288,11 +288,7 @@
         </bs-accordion-panel>
     </bs-accordion>
 
-    <div *ngIf="hasIdToken" class="row my-3">
+    <div class="row my-3">
         <div class="col"><button type="submit" class="btn btn-success">Create Rule</button></div>
     </div>
 </form>
-
-<div *ngIf="!hasIdToken" class="row my-3">
-    <div class="col"><button class="btn btn-primary" (click)="createUser()">Grant Offline Access</button></div>
-</div>

--- a/lib/src/rule_detail_component.dart
+++ b/lib/src/rule_detail_component.dart
@@ -15,9 +15,10 @@ import 'service/rule_service.dart';
   providers: [ClassProvider(ScheduleParser), ClassProvider(RuleService)],
 )
 class RuleDetailComponent implements AfterChanges {
-  String get idToken => window.localStorage['idToken'];
-  set idToken(String value) => window.localStorage['idToken'] = value;
-  bool get hasIdToken => window.localStorage.containsKey('idToken');
+  // Stores and retrieves the ID token from session storage.
+  String get idToken => window.sessionStorage['idToken'];
+  set idToken(String value) => window.sessionStorage['idToken'] = value;
+  bool get hasIdToken => window.sessionStorage.containsKey('idToken');
 
   // Maps from actual values to UI name.
   Map<Action_Type, String> actionTypes = {

--- a/lib/src/rule_list_component.dart
+++ b/lib/src/rule_list_component.dart
@@ -18,9 +18,10 @@ class RuleListComponent implements OnInit {
   final RuleService _ruleService;
   final List<Rule> rules = [];
 
-  String get idToken => window.localStorage['idToken'];
-  set idToken(String value) => window.localStorage['idToken'] = value;
-  bool get hasIdToken => window.localStorage.containsKey('idToken');
+  // Stores and retrieves the ID token from session storage.
+  String get idToken => window.sessionStorage['idToken'];
+  set idToken(String value) => window.sessionStorage['idToken'] = value;
+  bool get hasIdToken => window.sessionStorage.containsKey('idToken');
 
   Map<Action_Type, String> actionTypes = {
     for (var element in Action_Type.values.sublist(1))


### PR DESCRIPTION
This PR moves the sign in button from the rule creator view to the list view and uses session storage instead of local storage for the ID token. This is because the ID token expires after 1 hour, and there is limited time to implement a better solution. 